### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hurricane is a music player written in C# based on the [CSCore sound library](ht
 
 ![Overview](http://fs2.directupload.net/images/150220/vp9sem88.png)
 
-##Smart/Advanced view
+## Smart/Advanced view
 
 Hurricane provides two views: The smart view and the advanced view. The advanced view provides much information and is easy to use. The smart view is reduced to the essential functions. If you pin the window to the left or right side of your screen, it switches to the smart view and hides automatically if it loses focus. To bring it into the view again, move your cursor to the side where Hurricane has disappeared and an arrow will be shown: (Magic Arrow!)
 
@@ -14,7 +14,7 @@ Hurricane provides two views: The smart view and the advanced view. The advanced
 If you click on it, Hurricane appears.
 
 
-##Why Hurricane?
+## Why Hurricane?
 
  - Modern design
  - Tag editor
@@ -31,7 +31,7 @@ If you click on it, Hurricane appears.
  - Supports DirectSound and WASAPI
  
  
-##Screenshots
+## Screenshots
 Now Playing tab, advanced view:
 ![NowPlaying](http://fs2.directupload.net/images/150220/nscgvlkp.png)
 
@@ -43,12 +43,12 @@ Smart view:
 ![SmartView](http://fs2.directupload.net/images/150220/ulturivm.png)
 
 
-##Links
+## Links
 [website](http://www.hurricaneproject.org/)
 <br/>[vb-paradise.de](https://www.vb-paradise.de/index.php/Thread/108601-Hurricane)
 <br/>[chip.de](http://www.chip.de/downloads/Hurricane_77588182.html)
 <br/>[computerbild.de](http://www.computerbild.de/download/Hurricane-11742809.html)
 
 
-##License
+## License
 Hurricane is licensed under the [GNU General Public License](LICENSE.txt)

--- a/release-notes/0.2.5.md
+++ b/release-notes/0.2.5.md
@@ -1,4 +1,4 @@
-##Features
+## Features
 
 - Crossfade
 - Basethemes
@@ -10,7 +10,7 @@
 - Favorite list
 - Play-button selects automatically the first track if pressed without an opened track 
 
-##Bugfixes
+## Bugfixes
 
 - Fixed selecting all tracks (with ctrl+a)
 - Fixed displaying too long tracknames

--- a/release-notes/0.3.0.md
+++ b/release-notes/0.3.0.md
@@ -1,4 +1,4 @@
-##Features
+## Features
 
 - Streaming support for SoundCloud and YouTube
     - Can download the tracks
@@ -6,6 +6,6 @@
 - Add new language: finnish
 - New drag and drop framework
 
-##Bugfixes
+## Bugfixes
 - Fixed applying for themes
 - Fixed white spaces in list after removing duplicates

--- a/release-notes/0.3.1.md
+++ b/release-notes/0.3.1.md
@@ -1,4 +1,4 @@
-##Features
+## Features
 - Improved theme-change-animation
 - Don't have to reload the track after changing device
 - If you force the slider to jump to a point, you can also drag it now
@@ -9,7 +9,7 @@
 - Improved updater
 
 
-##Bugfixes
+## Bugfixes
 - Fixed drag & drop for one playlist/one track
 - Fixed apply button
 - Fixed NullReferenceException if searching empty text

--- a/release-notes/0.3.2.md
+++ b/release-notes/0.3.2.md
@@ -1,9 +1,9 @@
-##Features
+## Features
 - Background can be changed to a picture
 - Add a little opacity animation if window state changes (docked / undocked)
 - Now Hurricane can be minimized to the tray
 
-##Bugfixes
+## Bugfixes
 - Fixed display bug in the appearance settings tab
 - Fixed display bug in the about view
 - Make thin headers standard

--- a/release-notes/0.3.3.md
+++ b/release-notes/0.3.3.md
@@ -1,4 +1,4 @@
-##Features
+## Features
 - Cool new animation if track changes for smart view
 - Smooth cover art change
 - Video files can be set as background
@@ -8,7 +8,7 @@
 - The current progress in the taskbar can now be disabled
 - With ctrl+left and ctrl+right can you pin Hurricane now to the left/right side
 
-##Changes
+## Changes
 - Removed settings dialog for smart view
 - Removed spectrum analyzer color
 - Settings don't have to be applied any more
@@ -17,7 +17,7 @@
 - Now, only settings are saved in the config.xml and all current-state-info are saved in a new file, current.xml
 - Removed TCP-Api
 
-##Bugfixes
+## Bugfixes
 - If "Show artist and title in list" is changed, the list will refresh
 - Fixed sound out changing
 - Fixed image render quality

--- a/release-notes/0.3.4.md
+++ b/release-notes/0.3.4.md
@@ -1,9 +1,9 @@
-##Features
+## Features
 - Streams can be added to a new playlist
 - The tab control selected index gets saved now
 - Now you can switch the tab pages with Ctrl 1/2/3
 
-##Changes
+## Changes
 - New beautiful dark dialogs
 - Themes don't have to be applied any more
 - Better handling if no track is opened
@@ -14,7 +14,7 @@
 - Web searches are now sorted by views
 - Renamed basetheme to theme and color theme to accent color
 
-##Bugfixes
+## Bugfixes
 - Fixed updater FormatException
 - Fixed two Lastfm api exceptions
 - Improved removing of much tracks

--- a/release-notes/0.3.5.md
+++ b/release-notes/0.3.5.md
@@ -1,16 +1,16 @@
-##Features
+## Features
 - Added new language: dutch
 - App support
 - Right click on playlist shows some information
 - Shows keyboard shortcuts
 - Track duration can be cut
 
-##Changes
+## Changes
 - Added context menu to tray icon
 - Only streams audio
 - Made queue manager shortcut global for the application
 
-##Bugfixes
+## Bugfixes
 - Fixed bug with changing the sample rate
 - Dialog fix
 - Fixed a bug when trying to add a new stream to an existing playlist

--- a/release-notes/0.3.6.md
+++ b/release-notes/0.3.6.md
@@ -1,8 +1,8 @@
-##Features
+## Features
 - Much faster import of tracks
 - Thought the settings, you can force Hurricane to save everything to appdata or to the folder which contains the assembly
 
-##Changes
+## Changes
 - Changed animations for the listviews
 - The update installer closes automatically
 - Remove border of the stream list
@@ -10,7 +10,7 @@
 - The audio device list gets refreshed
 - If "Windows Default" is selected, the audio device gets changed automatically if the system default audio device is changed
 
-##Bugfixes
+## Bugfixes
 - Fixed a bug with the task bar progress while downloading an update
 - The path to the download directory doesn't get saved any more if it's the default path
 - The track list of the streams tab has a transparent background now

--- a/release-notes/0.3.7.md
+++ b/release-notes/0.3.7.md
@@ -1,8 +1,8 @@
-##Features
+## Features
 - Convert downloaded tracks
 - Settings for automatic updates
 
-##Changes
+## Changes
 - A click on the taskbar icon minimizes the window now
 - Enable windows key for the advanced view (win + left/right/top)
 - Remove maximize indicator
@@ -10,14 +10,14 @@
 - Designer improvements
 - Safer saving of the playlists
 
-##Bugfixes
+## Bugfixes
 - Fixed Exceptionless (sorry for that...)
 - Fixed an exception if the user closes the window right after pausing
 - Fixed an issue with downloaded tracks if the user installed Hurricane
 - Fixed a kbps display issue
 - Fixed an issue that jump to current track won't work if it's selected
 
-##Files to update
+## Files to update
 - Exceptionless.dll (update)
 - Exceptionless.Wpf.dll (update)
 - Exceptionless.Portable.dll

--- a/release-notes/0.3.8.md
+++ b/release-notes/0.3.8.md
@@ -1,4 +1,4 @@
-##Features
+## Features
 - (Add Grooveshark support)
 - Add custom streams support
 - New awesome animation for the track list (also for the smart view)
@@ -6,13 +6,13 @@
 - Add support for streams from playlist files (m3u)
 - Add Vkontakte support
 
-##Changes
+## Changes
 - Changes in the track information window are now live visible
 - "remove missing tracks" also checks online tracks
 - Improve the track search design
 - Update the tag editor
 
-##Bugfixes
+## Bugfixes
 - Fixed notifications
 - Fixed "WasapiOut is not initialized" error
 - Fixed save error
@@ -21,7 +21,7 @@
 - Fixed that invalid keyboard shortcuts could be used on non existing tracks
 - Fixed a bug with the playlist import that some tracks are not added
 
-##Files to update
+## Files to update
 - Exceptionless.Portable.dll
 - Exceptionless.Wpf.dll
 - HtmlAgilityPack.dll


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
