### PR TITLE
Continuing with ShuffleList after closing and opening Hurricane

### DIFF
--- a/Hurricane/Hurricane.csproj
+++ b/Hurricane/Hurricane.csproj
@@ -33,7 +33,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>

--- a/Hurricane/Music/Playlist/NormalPlaylist.cs
+++ b/Hurricane/Music/Playlist/NormalPlaylist.cs
@@ -23,6 +23,8 @@ namespace Hurricane.Music.Playlist
             }
         }
 
+        public DateTime TimeShuffeld { get; set; }
+
         public async Task AddFiles(IEnumerable<PlayableBase> tracks)
         {
             foreach (var track in tracks)

--- a/Hurricane/Music/Playlist/PlaylistBase.cs
+++ b/Hurricane/Music/Playlist/PlaylistBase.cs
@@ -75,7 +75,12 @@ namespace Hurricane.Music.Playlist
                 };
                 ViewSource = CollectionViewSource.GetDefaultView(Tracks);
                 ViewSource.Filter = item => string.IsNullOrWhiteSpace(SearchText) || item.ToString().ToUpper().Contains(SearchText.ToUpper());
-                ShuffleList = new List<PlayableBase>(Tracks);
+                if (this is NormalPlaylist) {
+                    var timeShuffeld = ((NormalPlaylist)this).TimeShuffeld;
+                    ShuffleList = new List<PlayableBase>(Tracks.Where(track => track.LastTimePlayed<timeShuffeld));
+                } else {
+                    ShuffleList = new List<PlayableBase>(Tracks);
+                }
             }
         }
 
@@ -89,6 +94,9 @@ namespace Hurricane.Music.Playlist
         private bool _addedFavoriteTracksTwoTimes;
         protected void CreateShuffleList()
         {
+            if (this is NormalPlaylist) {
+                ((NormalPlaylist)this).TimeShuffeld = DateTime.Now;
+            }
             ShuffleList = new List<PlayableBase>(Tracks);
             if (HurricaneSettings.Instance.Config.ShufflePreferFavoriteTracks)
             {


### PR DESCRIPTION
Old behaviour: When Hurricane starts, it generates a new ShuffleList containing all tracks

New behaviour: When Hurricane starts it generates a new ShuffleList containing only tracks which haven't been played in the previous session.

Reason for change: I listen to thousands of tracks and would like to hear them all, before they get repeated, even when I close and open Hurricane again.